### PR TITLE
fix Issue #43

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "valine",
+  "name": "valine-comment",
   "version": "1.1.8",
   "description": "A simple comment system based on Leancloud.",
   "main": "/src/Valine.js",


### PR DESCRIPTION
问题描述：
npm install valine --save  无法获得代码

报错：
Refusing to install valine as a dependency of itself

原因：
文件夹如果命名为Valine的时候。

参考：
https://stackoverflow.com/questions/27267707/npm-warn-install-refusing-to-install-hapi-as-a-dependency-of-itself