### PR TITLE
fix: 每次初始化都使用的是第一次的location.pathname

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,7 @@ function ValineFactory(option) {
  * Valine Init
  */
 ValineFactory.prototype.init = function (option) {
+    _path = location.pathname.replace(/index\.html?$/, '');
     let root = this;
     root['config'] = option
     if (typeof document === 'undefined') {
@@ -140,6 +141,7 @@ ValineFactory.prototype.init = function (option) {
 }
 
 ValineFactory.prototype._init = function(){
+        _path = location.pathname.replace(/index\.html?$/, '');
     let root = this;
     try {
         let {

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,6 @@ ValineFactory.prototype.init = function (option) {
 }
 
 ValineFactory.prototype._init = function(){
-        _path = location.pathname.replace(/index\.html?$/, '');
     let root = this;
     try {
         let {


### PR DESCRIPTION
原由：
我在给我的vuepress文档安装这个插件的时候发现的这个bug。发现每次初始化都使用的是第一次的location.pathname，

修复方式：
现在init方法里加入了更新的代码。