### PR TITLE
fix SEO by add alt for img

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -729,7 +729,7 @@ ValineFactory.prototype.bind = function (option) {
             'class': 'vcard',
             'id': rt.id
         });
-        let _img = _avatarSetting['hide'] ? '' : `<img class="vimg" src="${_avatarSetting['cdn']+md5(rt.get('mail'))+_avatarSetting['params']}">`;
+        let _img = _avatarSetting['hide'] ? '' : `<img class="vimg" src="${_avatarSetting['cdn']+md5(rt.get('mail'))+_avatarSetting['params']}" alt="${rt.get('nick')}">`;
         let ua = rt.get('ua') || '';
         let uaMeta = '';
         if (ua) {


### PR DESCRIPTION
I have been trying to keep the SEO of the page at 100.
However, the user's avatar `img` in valine lacks the `alt` attribute, which lowers the SEO score.

![image](https://user-images.githubusercontent.com/25154432/76765532-837c2b00-67d1-11ea-8903-907b4c00ea54.png)

