### PR TITLE
修改 macOS 操作系统显示的名称 Change the name for Macintosh OS

### DIFF
--- a/src/utils/detect.js
+++ b/src/utils/detect.js
@@ -41,7 +41,7 @@ function detectFactory(u) {
         //系统或平台
         'Windows': u.indexOf('Windows') > -1,
         'Linux': u.indexOf('Linux') > -1 || u.indexOf('X11') > -1,
-        'Mac OS': u.indexOf('Macintosh') > -1,
+        'macOS': u.indexOf('Macintosh') > -1,
         'Android': u.indexOf('Android') > -1 || u.indexOf('Adr') > -1,
         'Ubuntu': u.indexOf('Ubuntu') > -1,
         'FreeBSD': u.indexOf('FreeBSD') > -1,


### PR DESCRIPTION
根据 Apple 公司的写法规范，Macintosh 操作系统的写法应该是 macOS 而非 Mac OS