### PR TITLE
Add MathJax 3.0 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -767,6 +767,7 @@ ValineFactory.prototype.bind = function (option) {
             try {
                 // let MathJax = MathJax || '';
                 typeof MathJax !== 'undefined' && MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
+                typeof MathJax !== 'undefined' && MathJax.typeset();
                 if (typeof hljs !== 'undefined') {
                     Utils.each(Utils.findAll('pre code'), function (i, block) {
                         hljs.highlightBlock(block);


### PR DESCRIPTION
MathJax 3.0 has removed `MathJax.Hub`, so ` MathJax.Hub.Queue(["Typeset", MathJax.Hub])` will not work here. So add another line to use `MathJax.typeset()`. 

[Example website](https://yanqiyu.info/2020/03/30/Noetherstheorem/): Here I am using MathJax 3.0.1, with a modified version of Valine that supports Mathjax 3.0.( in this link, I removed MathJax 2.x support, but that was keeped in this commit/PR)