### PR TITLE
昵称和邮箱

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -843,6 +843,14 @@ ValineFactory.prototype.bind = function (option) {
             })
             return;
         }
+        if (defaultComment['nick'].length < 3) {
+            inputs['nick'].focus();
+            return;
+        }
+        if (defaultComment['mail'].length < 6 || defaultComment['mail'].indexOf('@') < 1 || defaultComment['mail'].indexOf('.') < 3) {
+            inputs['mail'].focus();
+            return;
+        }
         if (defaultComment['comment'] == '') {
             inputs['comment'].focus();
             return;


### PR DESCRIPTION
如果您希望保留匿名评论的选择，建议开放一个参数，让站长可以选择是否要求填写昵称和邮箱。

如果必须填写昵称和邮箱，则昵称至少3个字符，邮箱至少6个字符且必须包含`@`和`.` 
> 例如 `a@t.io` 这已经是邮箱的最短结构了