### PR TITLE
修复昵称字符数必须>=3的限制，改为>=1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -843,7 +843,7 @@ ValineFactory.prototype.bind = function (option) {
             })
             return;
         }
-        if (defaultComment['nick'].length < 3) {
+        if (defaultComment['nick'].length < 1) {
             inputs['nick'].focus();
             return;
         }


### PR DESCRIPTION
有些人的昵称就是两个字符，目前这个至少3个字符的逻辑有问题。

改正至少1个字符合理一点