### PR TITLE
fix(hash of mail): fix according to gravatar doc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -717,7 +717,7 @@ ValineFactory.prototype.bind = function (option) {
             'class': 'vcard',
             'id': rt.id
         });
-        let _img = _avatarSetting['hide'] ? '' : `<img class="vimg" src="${_avatarSetting['cdn']+md5(rt.get('mail'))+_avatarSetting['params']}">`;
+        let _img = _avatarSetting['hide'] ? '' : `<img class="vimg" src="${_avatarSetting['cdn']+md5(rt.get('mail').trim().toLowerCase())+_avatarSetting['params']}">`;
         let ua = rt.get('ua') || '';
         let uaMeta = '';
         if (ua) {


### PR DESCRIPTION
see <https://en.gravatar.com/site/implement/hash/>

2 steps are needed before hash:

1. Trim leading and trailing whitespace from an email address
2. Force all characters to lower-case